### PR TITLE
Fix json deserialization error on select value changed

### DIFF
--- a/SiemensIXBlazor/Components/Select/Select.razor.cs
+++ b/SiemensIXBlazor/Components/Select/Select.razor.cs
@@ -77,8 +77,14 @@ namespace SiemensIXBlazor.Components
 			else if(labels is JsonElement)
 			{
 				JsonElement jsonText = labels;
-				string[] labelArray = jsonText.Deserialize<string[]>()!;
-                await ValueChangeEvent.InvokeAsync(labelArray);
+
+				if (jsonText.ValueKind == JsonValueKind.Array) {
+					string[] labelArray = jsonText.Deserialize<string[]>()!;
+					await ValueChangeEvent.InvokeAsync(labelArray);
+				} else
+				{
+                    await ValueChangeEvent.InvokeAsync(jsonText.GetString());
+                }
             }
             
         }


### PR DESCRIPTION
Due to .NET internal transformation of the provided JSON array, it can happen that ValueChanged receives a JsonElement of type String instead of Array, resulting in an error then trying to deserialize it into an array. This commit fixes that.