### PR TITLE
Implement IconButton size

### DIFF
--- a/SiemensIXBlazor/Components/Button/IconButton.razor
+++ b/SiemensIXBlazor/Components/Button/IconButton.razor
@@ -15,5 +15,6 @@ color="@Color"
 icon="@Icon"
 oval="@Oval"
 loading="@Loading"
-data-tooltip="@DataTooltip">
+data-tooltip="@DataTooltip"
+size="@Size">
 </ix-icon-button>

--- a/SiemensIXBlazor/Components/Button/IconButton.razor.cs
+++ b/SiemensIXBlazor/Components/Button/IconButton.razor.cs
@@ -20,6 +20,8 @@ namespace SiemensIXBlazor.Components
         [Parameter]
         public bool? Oval { get; set; }
         [Parameter]
+        public IconButtonSize Size { get; set; } = IconButtonSize._24;
+        [Parameter]
         public bool Selected { get; set; } = false;
         [Parameter]
         public string DataTooltip { get; set; } = string.Empty;

--- a/SiemensIXBlazor/Enums/Button/IconButtonSize.cs
+++ b/SiemensIXBlazor/Enums/Button/IconButtonSize.cs
@@ -1,0 +1,9 @@
+﻿namespace SiemensIXBlazor.Enums.Button
+{
+    public enum IconButtonSize
+    {
+        _12 = 12,
+        _16 = 16,
+        _24 = 24
+    }
+}


### PR DESCRIPTION
The documentation defines a size property for icon buttons: (https://ix.siemens.io/docs/controls/button/#properties-ix-icon-button). This commit implements that, as discussed in #22 