### PR TITLE
Fixed IconButton size error

### DIFF
--- a/SiemensIXBlazor/Components/Button/IconButton.razor
+++ b/SiemensIXBlazor/Components/Button/IconButton.razor
@@ -16,5 +16,5 @@ icon="@Icon"
 oval="@Oval"
 loading="@Loading"
 data-tooltip="@DataTooltip"
-size="@Size">
+size="@((int)Size)">
 </ix-icon-button>


### PR DESCRIPTION
While creating #23 , I forgot to convert the enum correctly to an integer. This got noted by #24 and should be fixed by this commit.