### PR TITLE
Make AG-Grid JS instance accessible

### DIFF
--- a/SiemensIXBlazor/Components/AGGrid/AGGrid.razor.cs
+++ b/SiemensIXBlazor/Components/AGGrid/AGGrid.razor.cs
@@ -4,19 +4,19 @@ using Newtonsoft.Json;
 
 namespace SiemensIXBlazor.Components.AGGrid
 {
-    public partial class AGGrid
-    {
-        [Parameter, EditorRequired]
-        public string Id { get; set; } = string.Empty;
+	public partial class AGGrid
+	{
+		[Parameter, EditorRequired]
+		public string Id { get; set; } = string.Empty;
 
-        public async Task CreateGrid(GridOptions options)
-        {
-            if (Id == string.Empty)
-            {
-                return;
-            }
+		public async Task<IJSObjectReference?> CreateGrid(GridOptions options)
+		{
+			if (Id == string.Empty)
+			{
+				return null;
+			}
 
-            await JSRuntime.InvokeVoidAsync("agGridInterop.createGrid", Id, JsonConvert.SerializeObject(options));
-        }
-    }
+			return await JSRuntime.InvokeAsync<IJSObjectReference?>("agGridInterop.createGrid", Id, JsonConvert.SerializeObject(options));
+		}
+	}
 }


### PR DESCRIPTION
`window.agGridInterop.createGrid` returns the actual JS instance of the AG-Grid. This change exposes the return to the .NET side.